### PR TITLE
Add Fart

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -240,6 +240,11 @@ function is_compatible_arch() {
         return 0
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
+    elif [[ -n "${FARCH[*]}" ]]; then
+        if [[ " ${input[*]} " =~ " ${FARCH[*]} " ]]; then
+            fancy_message warn "This package is for a ${BBlue}foreign architecture${NC}"
+            return 0
+        fi
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
         return 1
@@ -704,6 +709,8 @@ export homedir
 sudo cp "${PACKAGE}.pacscript" /tmp
 pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
+mapfile -t FARCH < <(dpkg --print-foreign-architectures)
+export FARCH
 export CARCH="$(dpkg --print-architecture)"
 export DISTRO="$(set_distro)"
 if ! source "${pacfile}"; then


### PR DESCRIPTION
## Purpose

the is_compatible_arch check doesn't currently work for foreign architectures - i.e. if dpkg adds arm64 to an amd64 machine, CARCH won't do, so we need a solution.

## Approach

Make a FARCH variable array, test if it exists, and test if our input arch matches one of the FARCH outputs

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
