### PR TITLE
fix(pacstall): increase debug verbosity

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -37,6 +37,9 @@ export PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
 # (( )) doesn't like uninitialized vars
 export PACSTALL_INSTALL=1
 
+# declare verbose debug output
+declare -gx PS4=$'\U1F50D \E[0;10m\E[1m\033[1;31m\033[1;37m[\033[1;35m${BASH_SOURCE[0]##*/}:\033[1;34m${FUNCNAME[0]:-NOFUNC}():\033[1;33m${LINENO}\033[1;37m] - \033[1;33mDEBUG: \E[0;10m'
+
 # Colors
 export BOLD='\033[1m'
 export NC='\033[0m'


### PR DESCRIPTION
## Purpose

When looking for errors with Pacstall, we like to `set -x`. However, it is often confusing exactly which location/file each line is coming from.

## Approach

Add Elsie's custom PS4 prompt that increases debug verbosity to point to where execution is occurring 

## Progress

- [x] Add it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
